### PR TITLE
Modernise the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -23,104 +23,52 @@ under the License.
   <properties>
     <title>Download ${project.name} Source</title>
   </properties>
+
   <body>
     <section name="Download ${project.name} ${project.version} Source">
 
-      <p>${project.name} ${project.version} is distributed in source format. Use a source archive if you intend to build
-      ${project.name} yourself. Otherwise, simply use the ready-made binary artifacts from central repository.</p>
+      <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
 
-      <p>You will be prompted for a mirror - if the file is not found on yours, please be patient, as it may take 24
-      hours to reach all mirrors.<p/>
+      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
 
-      <p>In order to guard against corrupted downloads/installations, it is highly recommended to
-      <a href="https://www.apache.org/dev/release-signing#verifying-signature">verify the signature</a>
-      of the release bundles against the public <a href="https://www.apache.org/dist/maven/KEYS">KEYS</a> used by the Apache Maven
-      developers.</p>
+      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
 
-      <p>${project.name} is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
+      <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
-      <p></p>We <b>strongly</b> encourage our users to configure a Maven repository mirror closer to their location, please read <a href="/guides/mini/guide-mirror-settings.html">How to Use Mirrors for Repositories</a>.</p>
+      <subsection name="Files">
 
-      <a name="mirror"/>
-      <subsection name="Mirror">
+        <p>This is the current stable version of <strong>${project.name}</strong>.</p>
 
-        <p>
-          [if-any logo]
-          <a href="[link]">
-            <img align="right" src="[logo]" border="0"
-                 alt="logo"/>
-          </a>
-          [end]
-          The currently selected mirror is
-          <b>[preferred]</b>.
-          If you encounter a problem with this mirror,
-          please select another mirror.
-          If all mirrors are failing, there are
-          <i>backup</i>
-          mirrors
-          (at the end of the mirrors list) that should be available.
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Link</th>
+              <th>Checksum</th>
+              <th>Signature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>${project.name} ${project.version} (Source zip)</td>
+              <td><a href="https://dlcdn.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
+              <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512">${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
+              <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+          using the checksum (.sha512 file)
+          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
         </p>
 
-        <form action="[location]" method="get" id="SelectMirror">
-          Other mirrors:
-          <select name="Preferred">
-            [if-any http]
-            [for http]
-            <option value="[http]">[http]</option>
-            [end]
-            [end]
-            [if-any ftp]
-            [for ftp]
-            <option value="[ftp]">[ftp]</option>
-            [end]
-            [end]
-            [if-any backup]
-            [for backup]
-            <option value="[backup]">[backup] (backup)</option>
-            [end]
-            [end]
-          </select>
-          <input type="submit" value="Change"/>
-        </form>
-
-        <p>
-          You may also consult the
-          <a href="https://www.apache.org/mirrors/">complete list of
-            mirrors.</a>
-        </p>
-
-      </subsection>
-      
-      <subsection name="${project.name} ${project.version}">
-        
-      <p>This is the current stable version of ${project.name}.</p>
-        
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>Link</th>
-            <th>Checksum</th>
-            <th>Signature</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>${project.name} ${project.version} (Source zip)</td>
-            <td><a href="[preferred]maven/plugins/${project.artifactId}-${project.version}-source-release.zip">maven/plugins/${project.artifactId}-${project.version}-source-release.zip</a></td>
-            <td><a href="https://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
-            <td><a href="https://www.apache.org/dist/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
-          </tr>
-        </tbody>
-      </table>
       </subsection>
 
       <subsection name="Previous Versions">
-        
-      <p>Older non-recommended releases can be found on our <a href="http://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
-
+        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
+        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
       </subsection>
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
This page was last touched in 2018 and still carries the ASF **mirror-selection form**. The mirror network was retired in favour of a single CDN, so that form currently renders a "choose a mirror" dropdown offering exactly **one** entry, `dlcdn.apache.org`. The checksum, signature and KEYS links still point at `www.apache.org/dist`, which has been a **301 to `downloads.apache.org`** for years.

This finishes, for this repository, the "Refresh download page" sweep started in 2023 that stopped part-way through the estate. About 43 repositories are already on this exact form.

- artifact from `dlcdn.apache.org` — note the current page has **no usable artifact href at all** in the static HTML, only the `[preferred]` placeholder, which resolves solely when served through `mirrors.cgi`
- `.sha512` / `.asc` / `KEYS` from `downloads.apache.org`
- older releases from `archive.apache.org`, over https

### Two removals worth your attention

1. **In-page anchors.** `#mirror` and the version-numbered subsection anchor go away with the mirror section; the latter becomes the stable `#Files`. In-page only — no URL changes. You cannot delete the section and keep its anchor meaningfully.
2. **The `/guides/mini/guide-mirror-settings.html` paragraph.** That page is still live, but it is advice about configuring a *repository* mirror in `settings.xml`, not about downloading a source release, and **none** of the repositories already on the current form carry it. Dropping it is what converges this page with the rest of the estate — but say so on this PR if you would rather keep it here.

`download.cgi` is **left in place**: it is the canonical download URL for every component (`download.html` 301-redirects into it via a site-wide rule in `apache/maven-site`'s `.htaccess`), so removing it would 404 the download page.

The ASF licence header is left byte-for-byte as it was.

### Verification

Generated from a single canonical template that reproduces the existing form exactly; XML well-formedness checked, and a link-set audit run across all repositories in this sweep to confirm nothing is lost beyond the mirror-system leftovers listed above. Representative repositories were rendered before and after with a real site build. **This specific repository was not individually rendered** — flagging that rather than implying otherwise. Draft until CI is green.