### PR TITLE
Drop the FAQ anchor that duplicates the heading id

### DIFF
--- a/src/site/markdown/faq.md
+++ b/src/site/markdown/faq.md
@@ -28,8 +28,6 @@ under the License.
 1. [How can I specify a Class-Path: entry in the manifest of an Application Client jar?](#How_can_I_specify_a_Class-Path.3A_entry_in_the_manifest_of_an_Application_Client_jar.3F)
 2. [Why the app-client packaging type is not recognized?](#extensions)
 
-<a id="How_can_I_specify_a_Class-Path.3A_entry_in_the_manifest_of_an_Application_Client_jar.3F"></a>
-
 ### How can I specify a Class-Path: entry in the manifest of an Application Client jar?
 
 You just have to configure it:


### PR DESCRIPTION
Follow-up to #148, which converted this FAQ from FML to Markdown.

That conversion writes an explicit `<a id>` before every question so the live deep links keep working. For the **first** question the anchor it writes is byte-identical to the id Doxia already derives from the heading text, so the page carries the same id twice.

Duplicate ids are invalid HTML5 and Doxia logs `Anchor name "..." used more than once`. The heading already supplies that anchor, so the explicit one is dropped.

The second question keeps its explicit anchor: its FML id was `extensions`, which bears no relation to the heading text, so nothing else would generate it.

**Verified** by rebuilding: `faq.html` regenerated, no id appears twice, zero duplicate-anchor warnings, and every anchor served before is still served.

<sub>Drafted with Claude - please verify</sub>
